### PR TITLE
[개선] 스와이프 뷰

### DIFF
--- a/app/src/main/java/com/aone/menurandomchoice/utils/DisplayUtil.java
+++ b/app/src/main/java/com/aone/menurandomchoice/utils/DisplayUtil.java
@@ -1,0 +1,18 @@
+package com.aone.menurandomchoice.utils;
+
+import android.util.DisplayMetrics;
+
+import com.aone.menurandomchoice.GlobalApplication;
+
+public class DisplayUtil {
+
+    public static float convertToDP(float pixel) {
+        DisplayMetrics displayMetrics = GlobalApplication
+                .getGlobalApplicationContext()
+                .getResources()
+                .getDisplayMetrics();
+
+        return pixel / (displayMetrics.densityDpi / 160f);
+    }
+
+}

--- a/app/src/main/java/com/aone/menurandomchoice/views/menuselect/overlapview/animation/OverlapViewAnimationHelper.java
+++ b/app/src/main/java/com/aone/menurandomchoice/views/menuselect/overlapview/animation/OverlapViewAnimationHelper.java
@@ -10,6 +10,8 @@ public interface OverlapViewAnimationHelper {
     void executeDetachAnimation(@NonNull View topView,
                                 @NonNull RectF firstCoordinatesOfView,
                                 @NonNull RectF lastCoordinatesOfView,
+                                float xDragRatio,
+                                float yDragRatio,
                                 @NonNull OnAnimationStateListener onAnimationStateListener);
 
     void executeNotDetachAnimation(@NonNull View topView,

--- a/app/src/main/java/com/aone/menurandomchoice/views/menuselect/overlapview/animation/OverlapViewDefaultAnimation.java
+++ b/app/src/main/java/com/aone/menurandomchoice/views/menuselect/overlapview/animation/OverlapViewDefaultAnimation.java
@@ -5,20 +5,29 @@ import android.animation.AnimatorListenerAdapter;
 import android.graphics.RectF;
 import android.view.View;
 
+import com.aone.menurandomchoice.views.menuselect.overlapview.helper.DetachStateCalculator;
+
 import androidx.annotation.NonNull;
 
 public class OverlapViewDefaultAnimation implements OverlapViewAnimationHelper {
 
     private static final int PLAY_TIME = 200;
+    private static final float TRANSLATION_SENSITIVITY = 0.3f;
 
     @Override
     public void executeDetachAnimation(@NonNull final View topView,
                                        @NonNull final RectF firstCoordinatesOfView,
                                        @NonNull RectF lastCoordinatesOfView,
+                                       float xDragRatio,
+                                       float yDragRatio,
                                        @NonNull final OnAnimationStateListener onAnimationStateListener) {
+        float translationDistance = topView.getWidth() * TRANSLATION_SENSITIVITY;
+        float xDistance = translationDistance * xDragRatio;
+        float yDistance = translationDistance * yDragRatio;
+
         topView.animate()
-                .translationXBy(lastCoordinatesOfView.left - firstCoordinatesOfView.left)
-                .translationYBy(lastCoordinatesOfView.top - firstCoordinatesOfView.top)
+                .translationXBy(lastCoordinatesOfView.left + xDistance)
+                .translationYBy(lastCoordinatesOfView.top + yDistance)
                 .alpha(0)
                 .setDuration(PLAY_TIME)
                 .setListener(new AnimatorListenerAdapter() {

--- a/app/src/main/java/com/aone/menurandomchoice/views/menuselect/overlapview/helper/DetachStateCalculator.java
+++ b/app/src/main/java/com/aone/menurandomchoice/views/menuselect/overlapview/helper/DetachStateCalculator.java
@@ -1,8 +1,10 @@
 package com.aone.menurandomchoice.views.menuselect.overlapview.helper;
 
 import android.graphics.RectF;
+import android.util.Log;
 
 import com.aone.menurandomchoice.utils.DisplayUtil;
+import com.aone.menurandomchoice.views.menuselect.overlapview.model.DetachState;
 
 import androidx.annotation.NonNull;
 
@@ -21,7 +23,9 @@ public class DetachStateCalculator {
         NONE, LEFT, RIGHT, UP, DOWN, LEFT_UP, LEFT_DOWN, RIGHT_UP, RIGHT_DOWN
     }
 
-    public boolean isPossibleDetachView(@NonNull RectF oldViewRect, @NonNull RectF newViewRect, float xSpeedWithBasedPX, float ySpeedWithBasedPX) {
+
+    @NonNull
+    DetachState calculateDetachState(@NonNull RectF oldViewRect, @NonNull RectF newViewRect, float xSpeedWithBasedPX, float ySpeedWithBasedPX) {
         recordViewRect(oldViewRect, newViewRect);
         recordDragSpeedAfterConvertDP(xSpeedWithBasedPX, ySpeedWithBasedPX);
 
@@ -30,8 +34,16 @@ public class DetachStateCalculator {
 
         RectF rectOfAllowableLine = calculateRectOfAllowableLine();
         boolean isPassedAllowableLine = isPassedAllowableLine(rectOfAllowableLine);
+        boolean isDetachView = calculateDetachPossibility(isPassedAllowableLine, dragDirection, detachDirection);
 
-        return calculateDetachPossibility(isPassedAllowableLine, dragDirection, detachDirection);
+        return createDetachState(isDetachView);
+    }
+
+    private DetachState createDetachState(boolean isDetachView) {
+        float xDragRatio = xSpeedWithBasedDP/(Math.abs(xSpeedWithBasedDP) + Math.abs(ySpeedWithBasedDP));
+        float yDragRatio = ySpeedWithBasedDP/(Math.abs(xSpeedWithBasedDP) + Math.abs(ySpeedWithBasedDP));
+
+        return new DetachState(isDetachView, xDragRatio, yDragRatio);
     }
 
     private void recordViewRect(RectF oldViewRect, RectF newViewRect) {
@@ -242,4 +254,5 @@ public class DetachStateCalculator {
     private boolean isDirectionOfDrag(Direction dragDirection) {
         return dragDirection != Direction.NONE;
     }
+
 }

--- a/app/src/main/java/com/aone/menurandomchoice/views/menuselect/overlapview/helper/DetachStateCalculator.java
+++ b/app/src/main/java/com/aone/menurandomchoice/views/menuselect/overlapview/helper/DetachStateCalculator.java
@@ -1,0 +1,245 @@
+package com.aone.menurandomchoice.views.menuselect.overlapview.helper;
+
+import android.graphics.RectF;
+
+import com.aone.menurandomchoice.utils.DisplayUtil;
+
+import androidx.annotation.NonNull;
+
+public class DetachStateCalculator {
+
+    private static final float DETACH_ALLOW_RANGE = 0.35f;
+    private static final float ALLOWABLE_POSITIVE_SPEED = 50;
+    private static final float ALLOWABLE_NEGATIVE_SPEED = -50;
+
+    private RectF oldViewRect;
+    private RectF newViewRect;
+    private float xSpeedWithBasedDP;
+    private float ySpeedWithBasedDP;
+
+    enum Direction {
+        NONE, LEFT, RIGHT, UP, DOWN, LEFT_UP, LEFT_DOWN, RIGHT_UP, RIGHT_DOWN
+    }
+
+    public boolean isPossibleDetachView(@NonNull RectF oldViewRect, @NonNull RectF newViewRect, float xSpeedWithBasedPX, float ySpeedWithBasedPX) {
+        recordViewRect(oldViewRect, newViewRect);
+        recordDragSpeedAfterConvertDP(xSpeedWithBasedPX, ySpeedWithBasedPX);
+
+        Direction dragDirection = calculateDragDirection();
+        Direction detachDirection = calculateDetachDirection();
+
+        RectF rectOfAllowableLine = calculateRectOfAllowableLine();
+        boolean isPassedAllowableLine = isPassedAllowableLine(rectOfAllowableLine);
+
+        return calculateDetachPossibility(isPassedAllowableLine, dragDirection, detachDirection);
+    }
+
+    private void recordViewRect(RectF oldViewRect, RectF newViewRect) {
+        this.oldViewRect = oldViewRect;
+        this.newViewRect = newViewRect;
+    }
+
+    private void recordDragSpeedAfterConvertDP(float xSpeedWithBasedPX, float ySpeedWithBasedPX) {
+        xSpeedWithBasedDP = DisplayUtil.convertToDP(xSpeedWithBasedPX);
+        ySpeedWithBasedDP = DisplayUtil.convertToDP(ySpeedWithBasedPX);
+    }
+
+    private RectF calculateRectOfAllowableLine() {
+        float viewWidth = oldViewRect.right - oldViewRect.left;
+        float viewHeight = oldViewRect.bottom - oldViewRect.top;
+
+        float allowableWidth = viewWidth * DETACH_ALLOW_RANGE;
+        float allowableHeight = viewHeight * DETACH_ALLOW_RANGE;
+
+        float detachLineOfLeft = newViewRect.left + allowableWidth;
+        float detachLineOfTop = newViewRect.top + allowableHeight;
+        float detachLineOfRight = newViewRect.right - allowableWidth;
+        float detachLineOfBottom = newViewRect.bottom - allowableHeight;
+
+        return new RectF(detachLineOfLeft, detachLineOfTop, detachLineOfRight, detachLineOfBottom);
+    }
+
+    private boolean isPassedAllowableLine(RectF rectOfAllowableLine) {
+        return (rectOfAllowableLine.left <= oldViewRect.left)
+                || (oldViewRect.right <= rectOfAllowableLine.right)
+                || (rectOfAllowableLine.top <= oldViewRect.top)
+                || (oldViewRect.bottom <= rectOfAllowableLine.bottom);
+    }
+
+    private Direction calculateDragDirection() {
+        if(isSlowDragSpeed()) {
+            return Direction.NONE;
+        } else {
+            if (isRightDrag()) {
+                if (isDownDrag()) {
+                    return Direction.RIGHT_DOWN;
+                } else if (isUpDrag()) {
+                    return Direction.RIGHT_UP;
+                } else {
+                    return Direction.RIGHT;
+                }
+            } else if (isLeftDrag()) {
+                if (isDownDrag()) {
+                    return Direction.LEFT_DOWN;
+                } else if (isUpDrag()) {
+                    return Direction.LEFT_UP;
+                } else {
+                    return Direction.LEFT;
+                }
+            } else {
+                if (isDownDrag()) {
+                    return Direction.DOWN;
+                } else if (isUpDrag()) {
+                    return Direction.UP;
+                } else {
+                    return Direction.NONE;
+                }
+            }
+        }
+    }
+
+    private boolean isSlowDragSpeed() {
+        return ALLOWABLE_NEGATIVE_SPEED <= xSpeedWithBasedDP
+                && xSpeedWithBasedDP <= ALLOWABLE_POSITIVE_SPEED
+                && ALLOWABLE_NEGATIVE_SPEED <= ySpeedWithBasedDP
+                && ySpeedWithBasedDP <= ALLOWABLE_POSITIVE_SPEED;
+    }
+
+    private Direction calculateDetachDirection() {
+        if(isReachedRight()) {
+            if(isReachedBottom()) {
+                return Direction.RIGHT_DOWN;
+            } else if(isReachedTop()) {
+                return Direction.RIGHT_UP;
+            } else {
+                return Direction.RIGHT;
+            }
+        } else if(isReachedLeft()) {
+            if(isReachedBottom()) {
+                return Direction.LEFT_DOWN;
+            } else if(isReachedTop()) {
+                return Direction.LEFT_UP;
+            } else {
+                return Direction.LEFT;
+            }
+        } else {
+            if(isReachedBottom()) {
+                return Direction.DOWN;
+            } else if(isReachedTop()) {
+                return Direction.UP;
+            } else {
+                return Direction.NONE;
+            }
+        }
+    }
+
+    private boolean calculateDetachPossibility(boolean isPassedAllowableLine, Direction dragDirection, Direction detachDirection) {
+        if(isPassedAllowableLine) {
+            switch (detachDirection) {
+                case LEFT:
+                    return !isRightDirectionOfDrag(dragDirection);
+                case RIGHT:
+                    return !isLeftDirectionOfDrag(dragDirection);
+                case UP:
+                    return !isDownDirectionOfDrag(dragDirection);
+                case DOWN:
+                    return !isUpDirectionOfDrag(dragDirection);
+                case LEFT_UP:
+                    return !isRightDirectionOfDrag(dragDirection);
+                case LEFT_DOWN:
+                    return !isRightDirectionOfDrag(dragDirection);
+                case RIGHT_UP:
+                    return !isLeftDirectionOfDrag(dragDirection);
+                case RIGHT_DOWN:
+                    return !isLeftDirectionOfDrag(dragDirection);
+                    default:
+                        return true;
+            }
+        } else {
+            if(!isDirectionOfDrag(dragDirection)) {
+                return false;
+            } else {
+                switch (detachDirection) {
+                    case LEFT:
+                        return !isRightDirectionOfDrag(dragDirection);
+                    case RIGHT:
+                        return !isLeftDirectionOfDrag(dragDirection);
+                    case UP:
+                        return !isDownDirectionOfDrag(dragDirection);
+                    case DOWN:
+                        return !isUpDirectionOfDrag(dragDirection);
+                    case LEFT_UP:
+                        return dragDirection != Direction.RIGHT_DOWN;
+                    case LEFT_DOWN:
+                        return dragDirection != Direction.RIGHT_UP;
+                    case RIGHT_UP:
+                        return dragDirection != Direction.LEFT_DOWN;
+                    case RIGHT_DOWN:
+                        return dragDirection != Direction.LEFT_UP;
+                    default:
+                        return false;
+                }
+            }
+        }
+    }
+
+    private boolean isRightDrag() {
+        return 0 < xSpeedWithBasedDP;
+    }
+
+    private boolean isLeftDrag() {
+        return xSpeedWithBasedDP < 0;
+    }
+
+    private boolean isUpDrag() {
+        return ySpeedWithBasedDP < 0;
+    }
+
+    private boolean isDownDrag() {
+        return 0 < ySpeedWithBasedDP;
+    }
+
+    private boolean isReachedLeft() {
+        return newViewRect.left <= oldViewRect.left;
+    }
+
+    private boolean isReachedRight() {
+        return oldViewRect.right <= newViewRect.right;
+    }
+
+    private boolean isReachedTop() {
+        return newViewRect.top <= oldViewRect.top;
+    }
+
+    private boolean isReachedBottom() {
+        return oldViewRect.bottom <= newViewRect.bottom;
+    }
+
+    private boolean isRightDirectionOfDrag(Direction dragDirection) {
+        return dragDirection == Direction.RIGHT
+                || dragDirection == Direction.RIGHT_UP
+                || dragDirection == Direction.RIGHT_DOWN;
+    }
+
+    private boolean isLeftDirectionOfDrag(Direction dragDirection) {
+        return dragDirection == Direction.LEFT
+                || dragDirection == Direction.LEFT_UP
+                || dragDirection == Direction.LEFT_DOWN;
+    }
+
+    private boolean isUpDirectionOfDrag(Direction dragDirection) {
+        return dragDirection == Direction.UP
+                || dragDirection == Direction.LEFT_UP
+                || dragDirection == Direction.RIGHT_UP;
+    }
+
+    private boolean isDownDirectionOfDrag(Direction dragDirection) {
+        return dragDirection == Direction.DOWN
+                || dragDirection == Direction.LEFT_DOWN
+                || dragDirection == Direction.RIGHT_DOWN;
+    }
+
+    private boolean isDirectionOfDrag(Direction dragDirection) {
+        return dragDirection != Direction.NONE;
+    }
+}

--- a/app/src/main/java/com/aone/menurandomchoice/views/menuselect/overlapview/helper/OverlapViewTurnHelper.java
+++ b/app/src/main/java/com/aone/menurandomchoice/views/menuselect/overlapview/helper/OverlapViewTurnHelper.java
@@ -11,6 +11,7 @@ import com.aone.menurandomchoice.views.menuselect.overlapview.OverlapView;
 import com.aone.menurandomchoice.views.menuselect.overlapview.animation.OnAnimationStateListener;
 import com.aone.menurandomchoice.views.menuselect.overlapview.animation.OverlapViewAnimationHelper;
 import com.aone.menurandomchoice.views.menuselect.overlapview.animation.OverlapViewDefaultAnimation;
+import com.aone.menurandomchoice.views.menuselect.overlapview.model.DetachState;
 
 import androidx.annotation.NonNull;
 
@@ -21,7 +22,6 @@ public class OverlapViewTurnHelper {
     }
 
     private static final float ROTATE_SENSITIVITY = 0.03f;
-    private static final float DETACH_ALLOW_RANGE = 0.4f;
     private static final int DRAG_CALCULATE_UNIT_MS = 100;
 
     private OverlapViewAnimationHelper overlapViewAnimationHelper;
@@ -121,8 +121,9 @@ public class OverlapViewTurnHelper {
                     recyclerVelocityTracker();
 
                     recordCoordinatesOfNewTopView(topView);
-                    if(isDetachTopView() && isMoreChildView()) {
-                        requestDetachAnimationToHelper(topView);
+                    DetachState detachState = calculateDetachState();
+                    if(detachState.isDetach() && isMoreChildView()) {
+                        requestDetachAnimationToHelper(topView, detachState);
                     } else {
                         requestNotDetachAnimationToHelper(topView);
                     }
@@ -221,10 +222,12 @@ public class OverlapViewTurnHelper {
         }
     }
 
-    private void requestDetachAnimationToHelper(View topView) {
+    private void requestDetachAnimationToHelper(View topView, DetachState detachState) {
         overlapViewAnimationHelper.executeDetachAnimation(topView,
                 oldTopViewRect,
                 newTopViewRect,
+                detachState.getXDragRatio(),
+                detachState.getYDragRatio(),
                 new OnAnimationStateListener() {
                     @Override
                     public void onAnimationStart() {
@@ -260,8 +263,8 @@ public class OverlapViewTurnHelper {
         );
     }
 
-    private boolean isDetachTopView() {
-        return detachStateCalculator.isPossibleDetachView(oldTopViewRect,
+    private DetachState calculateDetachState() {
+        return detachStateCalculator.calculateDetachState(oldTopViewRect,
                 newTopViewRect,
                 xSpeedWithBasedPX,
                 ySpeedWithBasedPX);

--- a/app/src/main/java/com/aone/menurandomchoice/views/menuselect/overlapview/helper/OverlapViewTurnHelper.java
+++ b/app/src/main/java/com/aone/menurandomchoice/views/menuselect/overlapview/helper/OverlapViewTurnHelper.java
@@ -4,6 +4,7 @@ import android.annotation.SuppressLint;
 import android.graphics.PointF;
 import android.graphics.RectF;
 import android.view.MotionEvent;
+import android.view.VelocityTracker;
 import android.view.View;
 
 import com.aone.menurandomchoice.views.menuselect.overlapview.OverlapView;
@@ -21,6 +22,7 @@ public class OverlapViewTurnHelper {
 
     private static final float ROTATE_SENSITIVITY = 0.03f;
     private static final float DETACH_ALLOW_RANGE = 0.4f;
+    private static final int DRAG_CALCULATE_UNIT_MS = 100;
 
     private OverlapViewAnimationHelper overlapViewAnimationHelper;
     private OnTopViewDetachListener onTopViewDetachListener;
@@ -35,6 +37,12 @@ public class OverlapViewTurnHelper {
     private boolean isTouchingTopView = false;
     private boolean isAnimationPlaying = false;
 
+    private DetachStateCalculator detachStateCalculator;
+    private VelocityTracker velocityTracker;
+    private float xSpeedWithBasedPX;
+    private float ySpeedWithBasedPX;
+
+
     public OverlapViewTurnHelper() {
         setUp();
     }
@@ -46,6 +54,7 @@ public class OverlapViewTurnHelper {
         downTouchCoordinates = new PointF();
         moveTouchCoordinates = new PointF();
         viewTouchArea = ViewTouchArea.NONE;
+        detachStateCalculator = new DetachStateCalculator();
     }
 
     @SuppressLint("ClickableViewAccessibility")
@@ -84,6 +93,9 @@ public class OverlapViewTurnHelper {
             case MotionEvent.ACTION_DOWN:
                 isTouchingTopView = isTouchTopView(topView, event);
                 if(isTouchingTopView) {
+                    obtainVelocityTracker();
+                    velocityTracker.addMovement(event);
+
                     recordCoordinatesOfTouchDown(event);
                     recordCoordinatesOfOldTopView(topView);
                     recordViewTouchArea();
@@ -92,6 +104,8 @@ public class OverlapViewTurnHelper {
                 break;
             case MotionEvent.ACTION_MOVE:
                 if (isTouchingTopView) {
+                    velocityTracker.addMovement(event);
+
                     recordCoordinatesOfTouchMove(event);
                     PointF coordinatesToMove = calculateCoordinatesToMove();
                     moveTopViewToCoordinates(topView, coordinatesToMove);
@@ -102,8 +116,12 @@ public class OverlapViewTurnHelper {
             case MotionEvent.ACTION_UP:
                 if (isTouchingTopView) {
                     isTouchingTopView = false;
+
+                    recordDragSpeed();
+                    recyclerVelocityTracker();
+
                     recordCoordinatesOfNewTopView(topView);
-                    if(isDetachTopView(topView) && isMoreChildView()) {
+                    if(isDetachTopView() && isMoreChildView()) {
                         requestDetachAnimationToHelper(topView);
                     } else {
                         requestNotDetachAnimationToHelper(topView);
@@ -114,6 +132,25 @@ public class OverlapViewTurnHelper {
         }
 
         return true;
+    }
+
+    private void obtainVelocityTracker() {
+        if(velocityTracker == null) {
+            velocityTracker = VelocityTracker.obtain();
+        }
+    }
+
+    private void recyclerVelocityTracker() {
+        if(velocityTracker != null) {
+            velocityTracker.recycle();
+            velocityTracker = null;
+        }
+    }
+
+    private void recordDragSpeed() {
+        velocityTracker.computeCurrentVelocity(DRAG_CALCULATE_UNIT_MS);
+        xSpeedWithBasedPX = velocityTracker.getXVelocity();
+        ySpeedWithBasedPX = velocityTracker.getYVelocity();
     }
 
     private void recordCoordinatesOfTouchDown(MotionEvent event) {
@@ -223,17 +260,11 @@ public class OverlapViewTurnHelper {
         );
     }
 
-    private boolean isDetachTopView(View topView) {
-        float allowableWidth = topView.getWidth() * DETACH_ALLOW_RANGE;
-        float allowableHeight = topView.getHeight() * DETACH_ALLOW_RANGE;
-
-        float detachLineOfLeft = newTopViewRect.left + allowableWidth;
-        float detachLineOfTop = newTopViewRect.top + allowableHeight;
-        float detachLineOfRight = newTopViewRect.right - allowableWidth;
-        float detachLineOfBottom = newTopViewRect.bottom - allowableHeight;
-
-        return detachLineOfLeft <= oldTopViewRect.left || oldTopViewRect.right <= detachLineOfRight
-                || detachLineOfTop <= oldTopViewRect.top || oldTopViewRect.bottom <= detachLineOfBottom;
+    private boolean isDetachTopView() {
+        return detachStateCalculator.isPossibleDetachView(oldTopViewRect,
+                newTopViewRect,
+                xSpeedWithBasedPX,
+                ySpeedWithBasedPX);
     }
 
     private boolean isMoreChildView() {

--- a/app/src/main/java/com/aone/menurandomchoice/views/menuselect/overlapview/model/DetachState.java
+++ b/app/src/main/java/com/aone/menurandomchoice/views/menuselect/overlapview/model/DetachState.java
@@ -1,0 +1,27 @@
+package com.aone.menurandomchoice.views.menuselect.overlapview.model;
+
+public class DetachState {
+
+    private boolean isDetach;
+    private float xDragRatio;
+    private float yDragRatio;
+
+    public DetachState(boolean isDetach, float xDragRatio, float yDragRatio) {
+        this.isDetach = isDetach;
+        this.xDragRatio = xDragRatio;
+        this.yDragRatio = yDragRatio;
+    }
+
+    public boolean isDetach() {
+        return isDetach;
+    }
+
+    public float getXDragRatio() {
+        return xDragRatio;
+    }
+
+    public float getYDragRatio() {
+        return yDragRatio;
+    }
+
+}

--- a/app/src/main/res/layout/activity_menu_select.xml
+++ b/app/src/main/res/layout/activity_menu_select.xml
@@ -40,7 +40,6 @@
             android:layout_marginTop="@dimen/middle_margin"
             android:layout_marginRight="@dimen/middle_margin"
             android:layout_marginBottom="@dimen/middle_margin"
-            android:background="@android:color/white"
             app:layout_constraintBottom_toTopOf="@+id/activity_menu_select_btn"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/layout/item_menu_select_view.xml
+++ b/app/src/main/res/layout/item_menu_select_view.xml
@@ -13,7 +13,6 @@
     <androidx.constraintlayout.widget.ConstraintLayout
         xmlns:android="http://schemas.android.com/apk/res/android"
         xmlns:app="http://schemas.android.com/apk/res-auto"
-        android:background="@color/white"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical">


### PR DESCRIPTION
## 개요
- 한손으로 폰을 잡고 엄지손가락 사용시 좌->우는 잘되는편이나 우->좌 로 하는 경우 잘 안됨
- 해당 이슈를 해결하기 위한 다양한 테스트 및 개선 필요
## 작업 내용

![ezgif-1-6bbdae3dcc0c](https://user-images.githubusercontent.com/20294749/52913171-a1413d00-32fe-11e9-9ba1-e58f8113ee58.gif)

- view가 넘어가는 로직 변경
- 기존 : 상단 뷰가 최초 위치에서 일정 이상 넘어가면, 뷰가 떨어지도록 판정
- 개선 : 터치 드래그 속도 및 터치 방향성 반영하여 판정
   - 뷰가 일정 이상 넘어가지 않았다면
     1. 드래그의 속도를 확인하여, 특정 속도를 초과하는지 확인
     2. 일정 속도 이상 충족되지 않는다면 원래 자리로 돌아가도록 판정
     3. 일정 속도를 충족한다면 드래그의 방향성 확인
     4. x 축 드래그 방향과 y 축 드래그 방향을 확인하고, 드래그 방향에 맞추어 애니메이션 처리