### PR TITLE
[bug] 메뉴 편집화면 카테고리 적용 안되는 에러 해결

### DIFF
--- a/app/src/main/java/com/aone/menurandomchoice/views/menuregister/MenuRegisterPresenter.java
+++ b/app/src/main/java/com/aone/menurandomchoice/views/menuregister/MenuRegisterPresenter.java
@@ -302,7 +302,7 @@ public class MenuRegisterPresenter extends BasePresenter<MenuRegisterContract.Vi
         if(isAttachView()) {
             getView().setMenuDetailToDataBinding(menuDetail);
             if(menuCategoryAdapterModel != null) {
-                menuDetail.setCategory(menuDetail.getCategory());
+                menuCategoryAdapterModel.setCategory(menuDetail.getCategory());
             }
         }
     }


### PR DESCRIPTION
## 개요
- 업주가 기존에 등록했었던 메뉴를 편집하기 위해  편집화면에서 메뉴를 클릭
- 기존에 카테고리를 설정하여 메뉴를 등록해놨어도 무조건 한식으로 선택되어 있음

## 작업 내용
- category를 adapterModel이 아닌 menuDetail에 넣어주는 타이핑 에러 발견
- menuDetail.setCategory(category) -> adapterModel.setCategory(category)

resolved #77 