### PR TITLE
[bug] 메뉴 리스트 요청 실패 에러 해결

### DIFF
--- a/app/src/main/java/com/aone/menurandomchoice/repository/model/MenuSearchRequest.java
+++ b/app/src/main/java/com/aone/menurandomchoice/repository/model/MenuSearchRequest.java
@@ -49,6 +49,10 @@ public class MenuSearchRequest implements Parcelable {
         }
     };
 
+    public void removeCategory() {
+        category = "";
+    }
+
     public double getLatitude() {
         return latitude;
     }

--- a/app/src/main/java/com/aone/menurandomchoice/repository/remote/mapper/MenuMapper.java
+++ b/app/src/main/java/com/aone/menurandomchoice/repository/remote/mapper/MenuMapper.java
@@ -25,6 +25,8 @@ public class MenuMapper {
     private static final String QUERY_RADIUS = "radius";
     private static final String QUERY_CATEGORY = "category";
 
+    private static final String TAG_IMAGE_REGISTER_REQUEST = "photo";
+
     public static Map<String, String> createRequestLocationQueryMap(double latitude, double longitude){
         Map<String, String> queryMap = new HashMap<>();
         queryMap.put(QUERY_STRING_LATITUDE, latitude+"");
@@ -38,12 +40,14 @@ public class MenuMapper {
         queryMap.put(QUERY_STRING_LATITUDE, menuSearchRequest.getLatitude() + "");
         queryMap.put(QUERY_STRING_LONGITUDE, menuSearchRequest.getLongitude() + "");
 
-        if(menuSearchRequest.getRadius() != 0) {
-            queryMap.put(QUERY_RADIUS, menuSearchRequest.getRadius() + "");
+        int radius = menuSearchRequest.getRadius();
+        if(radius != 0) {
+            queryMap.put(QUERY_RADIUS, radius + "");
         }
 
-        if(menuSearchRequest.getCategory() != null && menuSearchRequest.getCategory().length() != 0) {
-            queryMap.put(QUERY_CATEGORY, menuSearchRequest.getCategory());
+        String category = menuSearchRequest.getCategory();
+        if(!TextUtils.isEmpty(category)) {
+            queryMap.put(QUERY_CATEGORY, category);
         }
 
         return queryMap;
@@ -58,7 +62,7 @@ public class MenuMapper {
                 if (!photoUrl.contains("http")) {
                     File file = new File(photoUrl);
                     RequestBody requestFile = RequestBody.create(MediaType.parse("multipart/form-data"), file);
-                    images.add(MultipartBody.Part.createFormData("photo", file.getName(), requestFile));
+                    images.add(MultipartBody.Part.createFormData(TAG_IMAGE_REGISTER_REQUEST, file.getName(), requestFile));
                 }
             }
         }

--- a/app/src/main/java/com/aone/menurandomchoice/views/menuselect/MenuSelectPresenter.java
+++ b/app/src/main/java/com/aone/menurandomchoice/views/menuselect/MenuSelectPresenter.java
@@ -100,11 +100,11 @@ public class MenuSelectPresenter extends BasePresenter<MenuSelectContract.View>
     }
 
     private void filteringCategoryOfRequest(MenuSearchRequest menuSearchRequest) {
-        String allCategory = GlobalApplication
+        String removeWord = GlobalApplication
                 .getGlobalApplicationContext()
                 .getString(R.string.arrays_category_all_food);
 
-        if(allCategory.equals(menuSearchRequest.getCategory())) {
+        if(removeWord.equals(menuSearchRequest.getCategory())) {
             menuSearchRequest.removeCategory();
         }
     }

--- a/app/src/main/java/com/aone/menurandomchoice/views/menuselect/MenuSelectPresenter.java
+++ b/app/src/main/java/com/aone/menurandomchoice/views/menuselect/MenuSelectPresenter.java
@@ -24,6 +24,7 @@ public class MenuSelectPresenter extends BasePresenter<MenuSelectContract.View>
     public void requestMenuList(@Nullable MenuSearchRequest menuSearchRequest) {
         if(menuSearchRequest != null) {
             showProgressBarOfView();
+            filteringCategoryOfRequest(menuSearchRequest);
             requestMenuDetailListToRepository(menuSearchRequest);
         } else {
             hideProgressBarOfView();
@@ -98,4 +99,13 @@ public class MenuSelectPresenter extends BasePresenter<MenuSelectContract.View>
         }
     }
 
+    private void filteringCategoryOfRequest(MenuSearchRequest menuSearchRequest) {
+        String allCategory = GlobalApplication
+                .getGlobalApplicationContext()
+                .getString(R.string.arrays_category_all_food);
+
+        if(allCategory.equals(menuSearchRequest.getCategory())) {
+            menuSearchRequest.removeCategory();
+        }
+    }
 }


### PR DESCRIPTION
## 개요
- 사용자 화면에서 카테고리를 '전체'로 설정하고 스와이프 시작 버튼 클릭
- 사용자 화면에서는 3개의 메뉴가 존재한다고 보여지지만 검색 요청 결과가 없다는 에러메시지가 나옴

## 작업 내용
- 카테고리가 '전체'일 경우, 서버에는 '전체' 카테고리가 존재하지 않아 요청을 받을 수 없음
- '전체' 카테고리를 적용하고 싶다면 카테고리를 전송하지 않아야 받을 수 있음
- 그러므로 presenter에서 '전체' 인 카테고리일 경우 ""로 변경하여 서버에 request 처리
 
resolved #80 