### PR TITLE
[bug]  맵에서  이동 시작하면 원만 지워짐, 없는 메뉴 갯수도 카운팅

### DIFF
--- a/app/src/main/java/com/aone/menurandomchoice/views/customermain/CustomerMainActivity.java
+++ b/app/src/main/java/com/aone/menurandomchoice/views/customermain/CustomerMainActivity.java
@@ -267,9 +267,7 @@ public class CustomerMainActivity extends BaseActivity<ActivityCustomerMainBindi
     public void onMapViewInitialized(MapView mapView) { }
 
     @Override
-    public void onMapViewCenterPointMoved(MapView mapView, MapPoint mapCenterPoint) {
-        mapView.removeAllCircles();
-    }
+    public void onMapViewCenterPointMoved(MapView mapView, MapPoint mapCenterPoint) { }
 
     @Override
     public void onMapViewMoveFinished(MapView mapView, MapPoint mapPoint) {
@@ -391,7 +389,7 @@ public class CustomerMainActivity extends BaseActivity<ActivityCustomerMainBindi
         Intent locationSearchIntent = new Intent(CustomerMainActivity.this
                                                 , LocationSearchActivity.class);
         locationSearchIntent.putExtra(getView().getActivityContext().getString(R.string.activity_store_edit_request_location_search)
-                , getView().getActivityContext().getString(R.string.activity_customer_main_descriptor));
+                                    , getView().getActivityContext().getString(R.string.activity_customer_main_descriptor));
         startActivityForResult(locationSearchIntent,LOCATION_DATA);
     }
 
@@ -399,7 +397,7 @@ public class CustomerMainActivity extends BaseActivity<ActivityCustomerMainBindi
         if(mMapView.getPOIItems().length > 1) {
             mMapView.removeAllCircles();
             Intent menuSelectIntent = new Intent(CustomerMainActivity.this
-                    , MenuSelectActivity.class);
+                                                , MenuSelectActivity.class);
             int radius = (int) getRadius();
             String category = getPresenter().getSelectedCategory();
 

--- a/app/src/main/java/com/aone/menurandomchoice/views/customermain/CustomerMainPresenter.java
+++ b/app/src/main/java/com/aone/menurandomchoice/views/customermain/CustomerMainPresenter.java
@@ -71,7 +71,9 @@ public class CustomerMainPresenter extends BasePresenter<CustomerMainContract.Vi
 
         for (int i = 0; i < len; i++) {
             menuLocation = menuList.get(i);
-            if((getView().getAppContext().getString(R.string.activity_customer_main_all_category)).equals(category) || (menuLocation.getCategory()).equals(category)) {
+            if(((getView().getAppContext().getString(R.string.activity_customer_main_all_category)).equals(category)
+                    && !((menuLocation.getCategory()).equals("")) )
+                    || (menuLocation.getCategory()).equals(category)) {
                 distance = LocationDistance.distance(centerLat
                                                         , centerLon
                                                         , menuLocation.getLatitude()


### PR DESCRIPTION
## 개요
- 이동시 마커와 핀들은 시작지점에 남아있는데 원만 먼저 지워짐
- 전체 카테고리 선택 후 메뉴 검색시 한 가게에 등록된 메뉴가 1개여도 무조건 3개로 카운팅

## 작업 내용
- `onMapViewCenterPointMoved` 콜백에서 원 지우는 함수 제거
- 카테고리 비교 로직에서 공백문자열인지 체크

resolved #83 #86 