### PR TITLE
등록되지 않은 메뉴를 터치했을 때, 접속되던 에러 해결

### DIFF
--- a/app/src/main/java/com/aone/menurandomchoice/repository/remote/APIRepository.java
+++ b/app/src/main/java/com/aone/menurandomchoice/repository/remote/APIRepository.java
@@ -151,9 +151,13 @@ public class APIRepository implements APIHelper {
     @Override
     public void requestSaveStoreDetail(@NonNull StoreDetail storeInfo,
                                        @NonNull NetworkResponseListener<EmptyObject> listener) {
-        apiCreator.getApiInstance()
-                .createStoreDetailSaveRequestCall(storeInfo, MenuMapper.createRegisteredImageList(storeInfo))
-                .enqueue(new JMTCallback<>(listener));
+        if(NetworkUtil.isNetworkConnecting()) {
+            apiCreator.getApiInstance()
+                    .createStoreDetailSaveRequestCall(storeInfo, MenuMapper.createRegisteredImageList(storeInfo))
+                    .enqueue(new JMTCallback<>(listener));
+        } else {
+            listener.onError(JMTErrorCode.NETWORK_NOT_CONNECT_ERROR);
+        }
     }
 
 }

--- a/app/src/main/java/com/aone/menurandomchoice/views/ownerstore/OwnerStorePresenter.java
+++ b/app/src/main/java/com/aone/menurandomchoice/views/ownerstore/OwnerStorePresenter.java
@@ -1,6 +1,7 @@
 package com.aone.menurandomchoice.views.ownerstore;
 
 import android.content.DialogInterface;
+import android.text.TextUtils;
 
 import com.aone.menurandomchoice.GlobalApplication;
 import com.aone.menurandomchoice.R;
@@ -35,14 +36,18 @@ public class OwnerStorePresenter extends BasePresenter<OwnerStoreContract.View> 
 
     @Override
     public void onMenuDetailClick(MenuDetail menuDetail) {
-        if(menuDetail.getPhotoUrl() == null)
-            return;
-        getView().moveToMenuPreviewPage(menuDetail);
+        if(TextUtils.isEmpty(menuDetail.getPhotoUrl())) {
+            sendMessageToView(R.string.activity_owner_detail_not_menu_page);
+        } else {
+            getView().moveToMenuPreviewPage(menuDetail);
+        }
     }
 
     @Override
     public void onMapClick(double latitude, double longitude) {
-        getView().moveToMapDetailPage(latitude, longitude);
+        if(isAttachView()) {
+            getView().moveToMapDetailPage(latitude, longitude);
+        }
     }
 
     @Override

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -52,6 +52,7 @@
     <string name="activity_owner_detail_name_label">가게이름</string>
     <string name="activity_owner_detail_time_label">운영시간</string>
     <string name="activity_owner_detail_logout_label">로그아웃</string>
+    <string name="activity_owner_detail_not_menu_page">메뉴가 존재하지 않습니다</string>
 
     <!-- activity_store_edit-->
     <string name="activity_store_edit_label">가게 편집</string>


### PR DESCRIPTION
## 개요
- 업주 상세화면에서 등록되지 않은 메뉴 view를 터치해도 미리보기 화면으로 넘어감
- 등록되지 않은 메뉴를 터치하면 넘어가지 못하도록 해야함

## 작업 내용
- 메뉴에 photoUrl이 없다면 접속하지 못하도록 막음

resolved #78 