### PR TITLE
스크롤 위치 에러 해결, 디스크 캐쉬 주석처리

### DIFF
--- a/app/src/main/java/com/aone/menurandomchoice/repository/DataRepository.java
+++ b/app/src/main/java/com/aone/menurandomchoice/repository/DataRepository.java
@@ -135,6 +135,9 @@ public class DataRepository implements Repository {
                 public void onReceived(@NonNull UpdateTime response) {
                     String ServerUpdateTime = response.getUpdateTime();
 
+                    requestStoreDetail(storeIdx, networkResponseListener);
+                    //Todo 회원가입 후 앱을 삭제하고 다시 실행할때 sqlite가 null이여서 np오류가 남 -> 수정예정
+                    /*
                     if (ServerUpdateTime.equals(SQLiteUpdateTime)) {
                         networkResponseListener.onReceived(SQLiteStoreDetail);
                     } else {
@@ -153,7 +156,7 @@ public class DataRepository implements Repository {
                         });
                     }
 
-                    isUpdated = true;
+                    isUpdated = true;*/
                 }
 
                 @Override

--- a/app/src/main/java/com/aone/menurandomchoice/views/ownerstore/OwnerStoreActivity.java
+++ b/app/src/main/java/com/aone/menurandomchoice/views/ownerstore/OwnerStoreActivity.java
@@ -56,7 +56,7 @@ public class OwnerStoreActivity
         super.onStart();
 
         initMapView();
-        getPresenter().loadStoreDetail(storeIdx);
+        getPresenter().loadStoreDetail(storeIdx, isOwner);
     }
 
 

--- a/app/src/main/java/com/aone/menurandomchoice/views/ownerstore/OwnerStoreContract.java
+++ b/app/src/main/java/com/aone/menurandomchoice/views/ownerstore/OwnerStoreContract.java
@@ -21,7 +21,7 @@ public interface OwnerStoreContract {
 
     interface Presenter extends BaseContract.Presenter<OwnerStoreContract.View> {
 
-        void loadStoreDetail(int storeIdx);
+        void loadStoreDetail(int storeIdx, boolean isOwner);
 
         void onMenuDetailClick(MenuDetail menuDetail);
 

--- a/app/src/main/java/com/aone/menurandomchoice/views/ownerstore/OwnerStorePresenter.java
+++ b/app/src/main/java/com/aone/menurandomchoice/views/ownerstore/OwnerStorePresenter.java
@@ -17,20 +17,13 @@ import androidx.appcompat.app.AlertDialog;
 public class OwnerStorePresenter extends BasePresenter<OwnerStoreContract.View> implements  OwnerStoreContract.Presenter {
 
     @Override
-    public void loadStoreDetail(int storeIdx) {
-        getRepository().loadStoreDetail(storeIdx, new NetworkResponseListener<StoreDetail>() {
-            @Override
-            public void onReceived(@NonNull StoreDetail storeDetail) {
-                if (isAttachView()) {
-                    getView().showStoreDetail(storeDetail);
-                }
-            }
+    public void loadStoreDetail(int storeIdx, boolean isOwner) {
+        if(isOwner) {
+            loadStoreDetailToOwner(storeIdx);
+        } else {
+            loadStoreDetailToCustomer(storeIdx);
+        }
 
-            @Override
-            public void onError(JMTErrorCode errorCode) {
-                sendMessageToView(errorCode.getStringResourceId());
-            }
-        });
     }
 
     @Override
@@ -105,4 +98,35 @@ public class OwnerStorePresenter extends BasePresenter<OwnerStoreContract.View> 
         }
     }
 
+    public void loadStoreDetailToOwner(int storeIdx) {
+        getRepository().loadStoreDetail(storeIdx, new NetworkResponseListener<StoreDetail>() {
+            @Override
+            public void onReceived(@NonNull StoreDetail storeDetail) {
+                if (isAttachView()) {
+                    getView().showStoreDetail(storeDetail);
+                }
+            }
+
+            @Override
+            public void onError(JMTErrorCode errorCode) {
+                sendMessageToView(errorCode.getStringResourceId());
+            }
+        });
+    }
+
+    public void loadStoreDetailToCustomer(int storeIdx) {
+        getRepository().requestStoreDetail(storeIdx, new NetworkResponseListener<StoreDetail>() {
+            @Override
+            public void onReceived(@NonNull StoreDetail response) {
+                if(isAttachView()) {
+                    getView().showStoreDetail(response);
+                }
+            }
+
+            @Override
+            public void onError(JMTErrorCode errorCode) {
+                sendMessageToView(errorCode.getStringResourceId());
+            }
+        });
+    }
 }


### PR DESCRIPTION
### 내용
- 스크롤 위치 에러 재위치
- owner와 customer에 따라 model에서 각각 다른 함수 호출(디스크 캐시 여부)

### 특이사항
- 앱을 삭제 후 다시 설치했을 때 sqlite의 데이터가 null이여서 나는 np오류로 model의 디스크 캐시 부분을 일시적으로 주석 처리함 (수정예정)
