### PR TITLE
[bug] diskcach로직 간소화, 앱 삭제 후 재다운로드 시 오류 해결,  스크롤 오류(feature/bug_scroll_diskcash)

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
 
     <application
         android:name=".GlobalApplication"
-        android:allowBackup="true"
+        android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"

--- a/app/src/main/java/com/aone/menurandomchoice/repository/DataRepository.java
+++ b/app/src/main/java/com/aone/menurandomchoice/repository/DataRepository.java
@@ -106,9 +106,9 @@ public class DataRepository implements Repository {
     }
 
     @Override
-    public void getUpdateTimeFromServer(int storeIdx,
+    public void requestUpdateTimeFromServer(int storeIdx,
                                   @NonNull NetworkResponseListener<UpdateTime> networkResponseListener) {
-        apiHelper.getUpdateTimeFromServer(storeIdx, networkResponseListener);
+        apiHelper.requestUpdateTimeFromServer(storeIdx, networkResponseListener);
     }
 
     @Override
@@ -120,7 +120,7 @@ public class DataRepository implements Repository {
     @Override
     public void loadStoreDetail(final int storeIdx,
                                  @NonNull final NetworkResponseListener<StoreDetail> networkResponseListener) {
-        getUpdateTimeFromServer(storeIdx, new NetworkResponseListener<UpdateTime>() {
+        requestUpdateTimeFromServer(storeIdx, new NetworkResponseListener<UpdateTime>() {
             @Override
             public void onReceived(@NonNull UpdateTime response) {
                 String serverUpdateTime = response.getUpdateTime();

--- a/app/src/main/java/com/aone/menurandomchoice/repository/DataRepository.java
+++ b/app/src/main/java/com/aone/menurandomchoice/repository/DataRepository.java
@@ -120,19 +120,30 @@ public class DataRepository implements Repository {
     @Override
     public void loadStoreDetail(final int storeIdx,
                                  @NonNull final NetworkResponseListener<StoreDetail> networkResponseListener) {
+
         requestUpdateTimeFromServer(storeIdx, new NetworkResponseListener<UpdateTime>() {
             @Override
             public void onReceived(@NonNull UpdateTime response) {
                 String serverUpdateTime = response.getUpdateTime();
 
-                if(isSameLocalUpdateTime(serverUpdateTime)) {
+                if (isSameLocalUpdateTime(serverUpdateTime)) {
                     StoreDetail SQLiteStoreDetail = getStoreDetail();
                     networkResponseListener.onReceived(SQLiteStoreDetail);
                 } else {
-                    requestStoreDetail(storeIdx, networkResponseListener);
+                    requestStoreDetail(storeIdx, new NetworkResponseListener<StoreDetail>() {
+                        @Override
+                        public void onReceived(@NonNull StoreDetail response) {
+                            updateStoreDetail(response);
+                            networkResponseListener.onReceived(response);
+                        }
+
+                        @Override
+                        public void onError(JMTErrorCode errorCode) {
+                            networkResponseListener.onError(errorCode);
+                        }
+                    });
                 }
             }
-
             @Override
             public void onError(JMTErrorCode errorCode) {
                 networkResponseListener.onError(errorCode);

--- a/app/src/main/java/com/aone/menurandomchoice/repository/local/db/SQLiteDatabaseHelper.java
+++ b/app/src/main/java/com/aone/menurandomchoice/repository/local/db/SQLiteDatabaseHelper.java
@@ -12,4 +12,5 @@ public interface SQLiteDatabaseHelper {
 
     void updateStoreDetail(@NonNull final StoreDetail storeDetail);
 
+    String getUpdateTimeFromSQLite();
 }

--- a/app/src/main/java/com/aone/menurandomchoice/repository/local/db/SQLiteDatabaseRepository.java
+++ b/app/src/main/java/com/aone/menurandomchoice/repository/local/db/SQLiteDatabaseRepository.java
@@ -120,7 +120,9 @@ public class SQLiteDatabaseRepository extends SQLiteOpenHelper implements SQLite
         Cursor cursor = db.rawQuery(STOREDETAIL_SELECT_QUERY, null);
         
         try {
-            while(cursor.moveToNext()) {
+            if (cursor != null && cursor.getCount() != 0) {
+                cursor.moveToFirst();
+
                 storeDetail.setName(cursor.getString(cursor.getColumnIndex(StoreTable.STORES_NAME.getColumnName())));
                 storeDetail.setOpentime(cursor.getString(cursor.getColumnIndex(StoreTable.STORES_OPENTIME.getColumnName())));
                 storeDetail.setClosetime(cursor.getString(cursor.getColumnIndex(StoreTable.STORES_CLOSETIME.getColumnName())));
@@ -130,6 +132,8 @@ public class SQLiteDatabaseRepository extends SQLiteOpenHelper implements SQLite
                 storeDetail.setLongitude(cursor.getDouble(cursor.getColumnIndex(StoreTable.STORES_LONGITUDE.getColumnName())));
                 storeDetail.setUpdateTime(cursor.getString(cursor.getColumnIndex(StoreTable.STORES_UPDATETIME.getColumnName())));
                 storeDetail.setMenuList(getMenuDetailList());
+            } else {
+                storeDetail = null;
             }
         } catch (Exception e) {
             Log.d(TAG, "Error Get Store Detail");
@@ -152,15 +156,20 @@ public class SQLiteDatabaseRepository extends SQLiteOpenHelper implements SQLite
         Cursor cursor = db.rawQuery(MenuDetails_SELECT_QUERY, null);
 
         try {
-            while(cursor.moveToNext()) {
-                MenuDetail menuDetail = new MenuDetail();
-                menuDetail.setName(cursor.getString(cursor.getColumnIndex(MenuTable.MENU_NAME.getColumnName())));
-                menuDetail.setPhotoUrl(cursor.getString(cursor.getColumnIndex(MenuTable.MENU_PHOTO_URL.getColumnName())));
-                menuDetail.setPrice(cursor.getInt(cursor.getColumnIndex(MenuTable.MENU_PRICE.getColumnName())));
-                menuDetail.setCategory(cursor.getString(cursor.getColumnIndex(MenuTable.MENU_CATEGORY.getColumnName())));
-                menuDetail.setDescription(cursor.getString(cursor.getColumnIndex(MenuTable.MENU_DESCRIPTION.getColumnName())));
-                menuDetail.setSequence(cursor.getInt(cursor.getColumnIndex(MenuTable.MENU_SEQUENCE.getColumnName())));
-                menuDetails.add(menuDetail);
+            if (cursor != null && cursor.getCount() != 0) {
+                cursor.moveToFirst();
+                do {
+                    MenuDetail menuDetail = new MenuDetail();
+                    menuDetail.setName(cursor.getString(cursor.getColumnIndex(MenuTable.MENU_NAME.getColumnName())));
+                    menuDetail.setPhotoUrl(cursor.getString(cursor.getColumnIndex(MenuTable.MENU_PHOTO_URL.getColumnName())));
+                    menuDetail.setPrice(cursor.getInt(cursor.getColumnIndex(MenuTable.MENU_PRICE.getColumnName())));
+                    menuDetail.setCategory(cursor.getString(cursor.getColumnIndex(MenuTable.MENU_CATEGORY.getColumnName())));
+                    menuDetail.setDescription(cursor.getString(cursor.getColumnIndex(MenuTable.MENU_DESCRIPTION.getColumnName())));
+                    menuDetail.setSequence(cursor.getInt(cursor.getColumnIndex(MenuTable.MENU_SEQUENCE.getColumnName())));
+                    menuDetails.add(menuDetail);
+                }  while (cursor.moveToNext());
+            } else {
+                menuDetails = null;
             }
         } catch (Exception e) {
             Log.d(TAG, "Error Get Menu Detail");
@@ -220,4 +229,30 @@ public class SQLiteDatabaseRepository extends SQLiteOpenHelper implements SQLite
         }
     }
 
+    @Override
+    public String getUpdateTimeFromSQLite() {
+
+        String STOREUPDATETIME_SELECT_QUERY = String.format("SELECT %s FROM %s",
+                StoreTable.STORES_UPDATETIME.getColumnName(), StoreTable.TABLE_NAME.getColumnName());
+
+        SQLiteDatabase db = getReadableDatabase();
+        Cursor cursor = db.rawQuery(STOREUPDATETIME_SELECT_QUERY, null);
+
+        String updateTime = "";
+
+        try {
+            if (cursor != null && cursor.getCount() != 0) {
+                cursor.moveToFirst();
+
+                updateTime = cursor.getString(cursor.getColumnIndex(StoreTable.STORES_UPDATETIME.getColumnName()));
+            }
+        } catch (Exception e) {
+            Log.d(TAG, "Error Get Store UpdateTime");
+        } finally {
+            if (cursor != null && !cursor.isClosed()) {
+                cursor.close();
+            }
+        }
+        return updateTime;
+    }
 }

--- a/app/src/main/java/com/aone/menurandomchoice/repository/model/UpdateTime.java
+++ b/app/src/main/java/com/aone/menurandomchoice/repository/model/UpdateTime.java
@@ -1,6 +1,7 @@
 package com.aone.menurandomchoice.repository.model;
 
 public class UpdateTime {
+
     private String updateTime;
 
     public UpdateTime(String updateTime) {
@@ -14,4 +15,5 @@ public class UpdateTime {
     public void setUpdateTime(String updateTime) {
         this.updateTime = updateTime;
     }
+
 }

--- a/app/src/main/java/com/aone/menurandomchoice/repository/remote/APIHelper.java
+++ b/app/src/main/java/com/aone/menurandomchoice/repository/remote/APIHelper.java
@@ -25,7 +25,7 @@ public interface APIHelper {
     void requestStoreDetail(int storeIdx,
                             @NonNull NetworkResponseListener<StoreDetail> networkResponseListener);
 
-    void checkStoreUpdated(int storeIdx,
+    void getUpdateTimeFromServer(int storeIdx,
                            @NonNull NetworkResponseListener<UpdateTime> networkResponseListener);
 
     void requestSignedUpCheck(long userId,

--- a/app/src/main/java/com/aone/menurandomchoice/repository/remote/APIHelper.java
+++ b/app/src/main/java/com/aone/menurandomchoice/repository/remote/APIHelper.java
@@ -25,7 +25,7 @@ public interface APIHelper {
     void requestStoreDetail(int storeIdx,
                             @NonNull NetworkResponseListener<StoreDetail> networkResponseListener);
 
-    void getUpdateTimeFromServer(int storeIdx,
+    void requestUpdateTimeFromServer(int storeIdx,
                            @NonNull NetworkResponseListener<UpdateTime> networkResponseListener);
 
     void requestSignedUpCheck(long userId,

--- a/app/src/main/java/com/aone/menurandomchoice/repository/remote/APIRepository.java
+++ b/app/src/main/java/com/aone/menurandomchoice/repository/remote/APIRepository.java
@@ -100,7 +100,7 @@ public class APIRepository implements APIHelper {
     }
 
     @Override
-    public void getUpdateTimeFromServer(int storeIdx,
+    public void requestUpdateTimeFromServer(int storeIdx,
                                   @NonNull NetworkResponseListener<UpdateTime> listener) {
         if(NetworkUtil.isNetworkConnecting()) {
             apiCreator.getApiInstance()

--- a/app/src/main/java/com/aone/menurandomchoice/repository/remote/APIRepository.java
+++ b/app/src/main/java/com/aone/menurandomchoice/repository/remote/APIRepository.java
@@ -100,7 +100,7 @@ public class APIRepository implements APIHelper {
     }
 
     @Override
-    public void checkStoreUpdated(int storeIdx,
+    public void getUpdateTimeFromServer(int storeIdx,
                                   @NonNull NetworkResponseListener<UpdateTime> listener) {
         if(NetworkUtil.isNetworkConnecting()) {
             apiCreator.getApiInstance()

--- a/app/src/main/java/com/aone/menurandomchoice/views/ownerlogin/OwnerLoginPresenter.java
+++ b/app/src/main/java/com/aone/menurandomchoice/views/ownerlogin/OwnerLoginPresenter.java
@@ -2,6 +2,7 @@ package com.aone.menurandomchoice.views.ownerlogin;
 
 import android.content.Intent;
 import android.content.res.Resources;
+import android.util.Log;
 
 import com.aone.menurandomchoice.GlobalApplication;
 import com.aone.menurandomchoice.R;
@@ -40,6 +41,9 @@ public class OwnerLoginPresenter extends BasePresenter<OwnerLoginContract.View>
         getRepository().requestSignedUpCheck(userId, new NetworkResponseListener<LoginData>() {
             @Override
             public void onReceived(@NonNull LoginData loginData) {
+                if(getRepository().getStoreDetail() == null) {
+                    getRepository().addDefaultStoreDetail();
+                }
                 moveToOwnerStoreActivity(loginData);
             }
 

--- a/app/src/main/java/com/aone/menurandomchoice/views/ownerstore/OwnerStoreActivity.java
+++ b/app/src/main/java/com/aone/menurandomchoice/views/ownerstore/OwnerStoreActivity.java
@@ -56,6 +56,7 @@ public class OwnerStoreActivity
         super.onStart();
 
         initMapView();
+        getDataBinding().activityOwnerStoreScroll.scrollTo(0, 0);
         getPresenter().loadStoreDetail(storeIdx, isOwner);
     }
 

--- a/app/src/main/java/com/aone/menurandomchoice/views/ownerstore/OwnerStorePresenter.java
+++ b/app/src/main/java/com/aone/menurandomchoice/views/ownerstore/OwnerStorePresenter.java
@@ -1,6 +1,7 @@
 package com.aone.menurandomchoice.views.ownerstore;
 
 import android.content.DialogInterface;
+import android.util.Log;
 
 import com.aone.menurandomchoice.GlobalApplication;
 import com.aone.menurandomchoice.R;
@@ -18,6 +19,7 @@ public class OwnerStorePresenter extends BasePresenter<OwnerStoreContract.View> 
 
     @Override
     public void loadStoreDetail(int storeIdx, boolean isOwner) {
+
         if(isOwner) {
             loadStoreDetailToOwner(storeIdx);
         } else {

--- a/app/src/main/res/layout/activity_owner_store.xml
+++ b/app/src/main/res/layout/activity_owner_store.xml
@@ -15,6 +15,7 @@
     </data>
 
     <ScrollView
+        android:id="@+id/activity_owner_store_scroll"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 


### PR DESCRIPTION
- diskcach 로직 간소화
 : 이전에는 isUpdated로 업데이트 유무를 메모리 캐시 해놓고, 이 flag를 통해 서버에서 수정시각을 가져오는 함수를 호출할지 말지를 결정
 -> 상세 화면 진입시 일단 서버에서 수정시각을 가져와 로컬의 수정시각과 비교하는 로직으로 간소화

- 회원가입 후 앱을 삭제하고 다시 다운받으면 sqlite 데이터가 null인 오류 해결
 : 로그인시 테이블 데이터가 null인지 확인 후 없을 경우 생성

- 스크롤 오류